### PR TITLE
Request python 3.10 instead of 3.9

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=>3.9
+  - python=>3.10
   - rioxarray 
   - geopandas 
   - opencv 


### PR DESCRIPTION
`|` for type hints not available in python 3.9 (added in python 3.10), and hence prevent installation on python 3.9.

resolves https://github.com/trchudley/pdemtools/issues/1