### PR TITLE
Fix `too many open files` #13

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - numpy
   - shapely
   - pyarrow
+  - fiona

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Conveniently search, download, and preprocess ArcticDEM and REMA 
 keywords = [ "geospatial", "elevation", "arcticdem", "rema", "dem",]
 classifiers = [ "Intended Audience :: Science/Research", "Programming Language :: Python :: 3", "License :: OSI Approved :: MIT License", "Operating System :: OS Independent", "Topic :: Scientific/Engineering", "Topic :: Scientific/Engineering :: GIS", "Topic :: Scientific/Engineering :: Image Processing",]
 requires-python = ">=3.9"
-dependencies = ["rioxarray", "rasterio", "geopandas", "pandas", "shapely", "numpy", "GDAL", "opencv-python", "scipy", "numba", "pyarrow",]  # GDAL
+dependencies = ["rioxarray", "rasterio", "geopandas", "pandas", "shapely", "numpy", "GDAL", "opencv-python", "scipy", "numba", "pyarrow", "fiona"]  # GDAL
 
 [[project.authors]]
 name = "Tom Chudley"


### PR DESCRIPTION
Fix the `too many open files` issue that occurs when loading many mosaics in succession, as described in issue #13 .