### PR TITLE
v1.1.1

### DIFF
--- a/src/pdemtools/__init__.py
+++ b/src/pdemtools/__init__.py
@@ -13,6 +13,6 @@ from . import _coreg
 from . import _geomorphometry
 from . import _utils
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __all__ = ["search", "DemAccessor"]

--- a/src/pdemtools/data.py
+++ b/src/pdemtools/data.py
@@ -39,7 +39,9 @@ def geoid_from_bedmachine(bm_fpath: str, target_rxd: DataArray) -> DataArray:
     geoid = rxr.open_rasterio(f"{bm_fpath}")["geoid"]
     geoid_crs = geoid.rio.crs
     geoid = geoid.squeeze().astype("float32").rio.write_crs(geoid_crs)
-    geoid = geoid.rio.reproject_match(target_rxd, Resampling.bilinear)
+    geoid = geoid.rio.reproject_match(
+        match_data_array=target_rxd, resampling=Resampling.bilinear
+    )
 
     return geoid.squeeze()
 
@@ -63,7 +65,9 @@ def geoid_from_raster(fpath: str, target_rxd: DataArray = None) -> DataArray:
     geoid = geoid.squeeze().astype("float32").rio.write_crs(geoid_crs)
 
     if target_rxd != None:
-        geoid = geoid.rio.reproject_match(target_rxd, Resampling.bilinear)
+        geoid = geoid.rio.reproject_match(
+            match_data_array=target_rxd, resampling=Resampling.bilinear
+        )
 
     return geoid.squeeze()
 


### PR DESCRIPTION
Fixes minor bug with `.rio.reproject_match()` that was causing some bugs when passing`target_rxr` and `Resampling.bilinear` as positional arguments rather than keyword arguments.