### PR TITLE
bug fix: change variable name aoi to bounds

### DIFF
--- a/src/pdemtools/load.py
+++ b/src/pdemtools/load.py
@@ -403,7 +403,7 @@ def mosaic(
 
         if len(tiles) < 1:
             raise ValueError(
-                f"No {dataset} mosaic tiles found to intersect with bounds {aoi}"
+                f"No {dataset} mosaic tiles found to intersect with bounds {bounds}"
             )
 
         # get aws filepaths from the tiles dataframe


### PR DESCRIPTION
Hey Tom, I had a chance to use pdemtools last week - very useful, thanks! 

This tiny PR fixes an issue with printing AOI bounds to the screen when those coordinates are out-of-bounds.